### PR TITLE
fix: Add automatic yes to APT prompts

### DIFF
--- a/install-verible/action.yml
+++ b/install-verible/action.yml
@@ -15,7 +15,7 @@ runs:
     - name: Install dependencies
       shell: bash
       run: |
-          sudo apt install curl jq wget
+          sudo apt install -y curl jq wget
     - name: Download and unpack Verible
       shell: bash
       run: |


### PR DESCRIPTION
Hi All,

This MR resolves the dependency installation error in `verible-actions-common/install-verible` caused by APT's interactive mode. The fix adds an automatic yes to APT prompts. The logs are attached below.

Let me know if you have any suggestions on this MR.

```log
Run chipsalliance/verible-formatter-action@main
Run source /etc/os-release
Running on Ubuntu Linux
Run sudo apt-get update -qq
  
Reading package lists...
Building dependency tree...
Reading state information...
git is already the newest version (1:2.43.0-1ubuntu7).
0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.
Run chipsalliance/verible-actions-common/install-verible@main
  with:
    github_token: ***
    verible_version: latest
Run sudo apt install curl jq wget
  sudo apt install curl jq wget
  shell: bash --noprofile --norc -e -o pipefail {0}
WARNING: apt does not have a stable CLI interface. Use with caution in scripts.
Reading package lists...
Building dependency tree...
Reading state information...
The following additional packages will be installed:
  libcurl4t64 libjq1 libonig5
The following NEW packages will be installed:
  curl jq libcurl4t64 libjq1 libonig5 wget
0 upgraded, 6 newly installed, 0 to remove and 0 not upgraded.
Need to get 1279 kB of archives.
After this operation, 3542 kB of additional disk space will be used.
Do you want to continue? [Y/n] Abort.
Error: Process completed with exit code 1.
```

Best,
Taras